### PR TITLE
add user-data-base64

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ENHANCEMENTS:
 
+* add the flag `--user-data-base64` about command `ucloud uhost create` to customize the startup behaviors when launching the uhost instance and the value must be base64-encode.(#55)
+
+## 0.1.34 (2020-11-11)
+
+ENHANCEMENTS:
+
 * add the flag `--user-data` about command `ucloud uhost create` to customize the startup behaviors when launching the uhost instance.(#54)
 * add the flag `--gpu-type` about command `ucloud uhost create` to define the type of GPU instance.(#54)
 

--- a/base/config.go
+++ b/base/config.go
@@ -39,7 +39,7 @@ const DefaultBaseURL = "https://api.ucloud.cn/"
 const DefaultProfile = "default"
 
 //Version 版本号
-const Version = "0.1.34"
+const Version = "0.1.35"
 
 var UserAgent = fmt.Sprintf("UCloud-CLI/%s", Version)
 

--- a/base/util.go
+++ b/base/util.go
@@ -2,6 +2,7 @@ package base
 
 import (
 	"bufio"
+	"encoding/base64"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -698,4 +699,9 @@ func getDefaultProject(cookie, csrfToken string) (string, string, error) {
 		}
 	}
 	return "", "", fmt.Errorf("default project not found")
+}
+
+func IsBase64Encoded(data []byte) bool {
+	_, err := base64.StdEncoding.DecodeString(string(data))
+	return err == nil
 }


### PR DESCRIPTION
ENHANCEMENTS:

* add the flag `--user-data-base64` about command `ucloud uhost create` to customize the startup behaviors when launching the uhost instance and the value must be base64-encode.