### PR TITLE
chore: align Makefile VERSION and backfill 0.3.2/0.3.3 changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,12 @@
+## 0.3.3 (2026-06-18)
+
+* chore: bump `base.Version` to 0.3.3 to match the release tag
+
+## 0.3.2 (2026-06-18)
+
+* `mysql db create`: switch to the latest UDB create API and improve usability
+* expose the `mysql db list-machine-type` command
+
 ## 0.3.1 (2026-06-11)
 
 * OAuth browser login: `ucloud auth login` / `ucloud auth logout` (RFC 8252 loopback auto-capture, `--no-browser` fallback)

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-export VERSION=0.3.0
+export VERSION=0.3.3
 
 GOFMT_FILES?=$$(find . -name '*.go' |grep -v vendor)
 


### PR DESCRIPTION
## What

Backfill version metadata that the `Bump version 0.3.1 -> 0.3.3` change ([#98](https://github.com/ucloud/ucloud-cli/pull/98)) left out.

- **Makefile**: `export VERSION` was still `0.3.0` (it was never bumped, not even for 0.3.1). Aligned to `0.3.3` to match `base.Version`. Note: this variable is currently unreferenced by any target — release builds derive the version from the git tag (`hack/github-release.sh`) — so this is a consistency fix only.
- **CHANGELOG.md**: tags `v0.3.2` and `v0.3.3` shipped with no changelog entries. Added:
  - `0.3.2` — `mysql db create` switched to the latest UDB create API; exposed `mysql db list-machine-type`
  - `0.3.3` — version bump

## Verification

- `go build` passes
- `ucloud --version` → `ucloud cli 0.3.3`

🤖 Generated with [Claude Code](https://claude.com/claude-code)