### PR TITLE
feat(memcache): add resize command

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -10,8 +10,7 @@ require (
 	github.com/sirupsen/logrus v1.3.0
 	github.com/spf13/cobra v1.10.2
 	github.com/spf13/pflag v1.0.10
-	github.com/ucloud/ucloud-sdk-go v0.22.89
-	golang.org/x/sys v0.0.0-20220422013727-9388b58f7150
+	github.com/ucloud/ucloud-sdk-go v0.22.90
 	gopkg.in/yaml.v2 v2.2.2
 )
 
@@ -25,5 +24,6 @@ require (
 	github.com/russross/blackfriday/v2 v2.1.0 // indirect
 	go.yaml.in/yaml/v3 v3.0.4 // indirect
 	golang.org/x/crypto v0.0.0-20191011191535-87dc89f01550 // indirect
+	golang.org/x/sys v0.0.0-20220422013727-9388b58f7150 // indirect
 	gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -38,8 +38,8 @@ github.com/spf13/pflag v1.0.10/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3A
 github.com/stretchr/objx v0.1.1/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/testify v1.2.2 h1:bSDNvY7ZPG5RlJ8otE/7V6gMiyenm9RtJ7IUVIAoJ1w=
 github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
-github.com/ucloud/ucloud-sdk-go v0.22.89 h1:eCvCtkan5KIzzBv+QJgEQojCbwwS+hVtOq52hfGnWtg=
-github.com/ucloud/ucloud-sdk-go v0.22.89/go.mod h1:dyLmFHmUfgb4RZKYQP9IArlvQ2pxzFthfhwxRzOEPIw=
+github.com/ucloud/ucloud-sdk-go v0.22.90 h1:OYYPYlWZFQ5DB15akEkrd/ty28zkd6Als7PQ6shywzk=
+github.com/ucloud/ucloud-sdk-go v0.22.90/go.mod h1:dyLmFHmUfgb4RZKYQP9IArlvQ2pxzFthfhwxRzOEPIw=
 go.yaml.in/yaml/v3 v3.0.4 h1:tfq32ie2Jv2UxXFdLJdh3jXuOzWiL1fo0bu/FbuKpbc=
 go.yaml.in/yaml/v3 v3.0.4/go.mod h1:DhzuOOF2ATzADvBadXxruRBLzYTpT36CKvDb3+aBEFg=
 golang.org/x/crypto v0.0.0-20180904163835-0709b304e793/go.mod h1:6SG95UA2DQfeDnfUPMdvaQW0Q7yPrPDi9nlGo2tz2b4=

--- a/products/memcache/internal/memcache/cmd.go
+++ b/products/memcache/internal/memcache/cmd.go
@@ -17,5 +17,6 @@ func NewCommand(ctx *cli.Context) *cobra.Command {
 	cmd.AddCommand(newCreate(ctx))
 	cmd.AddCommand(newDelete(ctx))
 	cmd.AddCommand(newRestart(ctx))
+	cmd.AddCommand(newResize(ctx))
 	return cmd
 }

--- a/products/memcache/internal/memcache/resize.go
+++ b/products/memcache/internal/memcache/resize.go
@@ -1,0 +1,82 @@
+package memcache
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+
+	"github.com/ucloud/ucloud-sdk-go/services/umem"
+	"github.com/ucloud/ucloud-sdk-go/ucloud/request"
+
+	"github.com/ucloud/ucloud-cli/pkg/cli"
+	"github.com/ucloud/ucloud-cli/pkg/command"
+)
+
+// newResize returns ucloud memcache resize.
+func newResize(ctx *cli.Context) *cobra.Command {
+	idNames := make([]string, 0)
+	client := cli.NewServiceClient(ctx, umem.NewClient)
+	req := client.NewResizeUMemcacheGroupRequest()
+	cmd := &cobra.Command{
+		Use:   "resize",
+		Short: "Resize memcache instances",
+		Long:  "Resize memcache instances",
+		Run: func(c *cobra.Command, args []string) {
+			reqs := make([]request.Common, len(idNames))
+			for idx, idname := range idNames {
+				id := ctx.PickResourceID(idname)
+				next := *req
+				next.GroupId = &id
+				reqs[idx] = &next
+			}
+			prog := ctx.NewProgress()
+			if len(reqs) > 5 {
+				prog.Disable()
+			}
+			ctx.ConcurrentAction(reqs, 10, resize(ctx, client, prog))
+		},
+	}
+
+	flags := cmd.Flags()
+	flags.SortFlags = false
+
+	flags.StringSliceVar(&idNames, "umem-id", nil, "Required. Resource ID of memcache to resize")
+	req.Size = flags.Int("size-gb", 0, "Required. Target memory size in GB. Accept values:1,2,4,8,16,32")
+	ctx.BindRegion(cmd, req)
+	ctx.BindZone(cmd, req)
+	ctx.BindProjectID(cmd, req)
+
+	command.SetCompletion(cmd, "umem-id", func() []string {
+		return getIDList(ctx, *req.ProjectId, *req.Region)
+	})
+	command.SetFlagValues(cmd, "size-gb", "1", "2", "4", "8", "16", "32")
+
+	cmd.MarkFlagRequired("umem-id")
+	cmd.MarkFlagRequired("size-gb")
+	return cmd
+}
+
+func resize(ctx *cli.Context, client *umem.UMemClient, prog *cli.Progress) func(request.Common) (bool, []string) {
+	return func(creq request.Common) (bool, []string) {
+		req := creq.(*umem.ResizeUMemcacheGroupRequest)
+		block := prog.NewBlock()
+		logs := []string{}
+		_, err := client.ResizeUMemcacheGroup(req)
+		if err != nil {
+			msg := fmt.Sprintf("resize memcache[%s] failed: %s", *req.GroupId, cli.ParseError(err))
+			block.Append(cli.ParseError(err))
+			logs = append(logs, msg)
+			return false, logs
+		}
+		text := fmt.Sprintf("memcache[%s] is resizing", *req.GroupId)
+		ret := ctx.PollerTo(ctx.ProgressWriter(), describeByID(ctx)).Sspoll(*req.GroupId, text, []string{UMEM_RUNNING, UMEM_FAIL}, block, nil)
+		if ret.Err != nil {
+			block.Append(cli.ParseError(ret.Err))
+			logs = append(logs, ret.Err.Error())
+		}
+		if ret.Timeout {
+			logs = append(logs, fmt.Sprintf("poll memcache[%s] timeout", *req.GroupId))
+		}
+		return ret.Done, logs
+	}
+}

--- a/products/memcache/product.yaml
+++ b/products/memcache/product.yaml
@@ -1,6 +1,6 @@
 name: memcache
 owners:
-  - Episkey-G
+  - ucloud-umem-qingpfang
 commands:
   - memcache
 enabled: true

--- a/products/memcache/testdata/cmdtree.golden
+++ b/products/memcache/testdata/cmdtree.golden
@@ -22,6 +22,12 @@ ucloud memcache list	use=list	short=List memcache instances
   flag=region	short=	default=	required=
   flag=umem-id	short=	default=	required=
   flag=zone	short=	default=	required=
+ucloud memcache resize	use=resize	short=Resize memcache instances
+  flag=project-id	short=	default=	required=
+  flag=region	short=	default=	required=
+  flag=size-gb	short=	default=0	required=true
+  flag=umem-id	short=	default=[]	required=true
+  flag=zone	short=	default=	required=
 ucloud memcache restart	use=restart	short=Restart memcache instances
   flag=project-id	short=	default=	required=
   flag=region	short=	default=	required=

--- a/products/memcache/testdata/completion.golden
+++ b/products/memcache/testdata/completion.golden
@@ -12,6 +12,11 @@ ucloud memcache delete	zone	dynamic
 ucloud memcache list	project-id	dynamic
 ucloud memcache list	region	dynamic
 ucloud memcache list	zone	dynamic
+ucloud memcache resize	project-id	dynamic
+ucloud memcache resize	region	dynamic
+ucloud memcache resize	size-gb	static	1,16,2,32,4,8
+ucloud memcache resize	umem-id	dynamic
+ucloud memcache resize	zone	dynamic
 ucloud memcache restart	project-id	dynamic
 ucloud memcache restart	region	dynamic
 ucloud memcache restart	umem-id	dynamic


### PR DESCRIPTION
## Summary

Add a `resize` command to the `memcache` product.

## Changes
- **memcache**: add `resize` command
- Bump `github.com/ucloud/ucloud-sdk-go` to `v0.22.90` (required for
  `NewResizeUMemcacheGroupRequest` / `ResizeUMemcacheGroup`)
- Update `cmdtree` / `completion` golden testdata for memcache

## Verification
- `go build ./products/memcache/...` passes.
