### PR TITLE
feat(cli): add --wait-timeout-sec to configure synchronous poll timeout (#119)

### DIFF
--- a/cmd/internal/platform/config.go
+++ b/cmd/internal/platform/config.go
@@ -103,6 +103,7 @@ type GlobalFlag struct {
 	PrivateKey    string
 	BaseURL       string
 	Timeout       int
+	WaitTimeout   int // 同步轮询总超时（秒），0 表示用内置默认（600s）
 	MaxRetryTimes int
 }
 

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -324,14 +324,6 @@ func init() {
 				global.Timeout = sec
 			}
 		}
-		if arg == "--wait-timeout-sec" && len(os.Args) > idx+1 && os.Args[idx+1] != "" {
-			sec, err := strconv.Atoi(os.Args[idx+1])
-			if err != nil {
-				fmt.Printf("parse wait-timeout-sec failed: %v\n", err)
-			} else {
-				global.WaitTimeout = sec
-			}
-		}
 		if arg == "--max-retry-times" && len(os.Args) > idx+1 && os.Args[idx+1] != "" {
 			times, err := strconv.Atoi(os.Args[idx+1])
 			if err != nil {
@@ -341,7 +333,38 @@ func init() {
 			}
 		}
 	}
+	if sec, found, err := parseWaitTimeoutSec(os.Args); found {
+		if err != nil {
+			fmt.Printf("parse wait-timeout-sec failed: %v\n", err)
+		} else {
+			global.WaitTimeout = sec
+		}
+	}
 	cobra.EnableCommandSorting = false
+}
+
+// parseWaitTimeoutSec scans args for --wait-timeout-sec in either
+// `--wait-timeout-sec N` or `--wait-timeout-sec=N` form. found=true when
+// the flag is present with a value; err is set when that value isn't an int.
+func parseWaitTimeoutSec(args []string) (sec int, found bool, err error) {
+	const flag = "--wait-timeout-sec"
+	for idx, arg := range args {
+		if arg == flag {
+			if len(args) > idx+1 && args[idx+1] != "" {
+				sec, err = strconv.Atoi(args[idx+1])
+				return sec, true, err
+			}
+			continue
+		}
+		if val, ok := strings.CutPrefix(arg, flag+"="); ok {
+			if val == "" {
+				continue
+			}
+			sec, err = strconv.Atoi(val)
+			return sec, true, err
+		}
+	}
+	return 0, false, nil
 }
 
 func resetHelpFunc(cmd *cobra.Command) {

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -244,7 +244,7 @@ func Execute() {
 	}
 	platform.InitConfig()
 	if global.WaitTimeout > 0 {
-		cli.SetDefaultPollTimeout(time.Duration(global.WaitTimeout) * time.Second)
+		cli.SetUserPollTimeout(time.Duration(global.WaitTimeout) * time.Second)
 	}
 	setActiveRuntimeFromBaseGlobals()
 	mode := os.Getenv("UCLOUD_CLI_DEBUG")

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -20,6 +20,7 @@ import (
 	"os"
 	"strconv"
 	"strings"
+	"time"
 
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
@@ -190,6 +191,7 @@ func applyGlobalOverrideFlags(root *cobra.Command) {
 			c.PersistentFlags().StringVar(&global.PrivateKey, "private-key", global.PrivateKey, "Set private-key to override the private-key in local config file")
 			c.PersistentFlags().StringVar(&global.BaseURL, "base-url", "", "Set base-url to override the base-url in local config file")
 			c.PersistentFlags().IntVar(&global.Timeout, "timeout-sec", 0, "Set timeout-sec to override the timeout-sec in local config file")
+			c.PersistentFlags().IntVar(&global.WaitTimeout, "wait-timeout-sec", 0, "Set the total timeout in seconds for synchronous wait/poll (e.g. cluster/host create). 0 uses the built-in default (600s)")
 			c.PersistentFlags().IntVar(&global.MaxRetryTimes, "max-retry-times", -1, "Set max-retry-times to override the max-retry-times in local config file")
 		}
 	}
@@ -241,6 +243,9 @@ func Execute() {
 		}
 	}
 	platform.InitConfig()
+	if global.WaitTimeout > 0 {
+		cli.SetDefaultPollTimeout(time.Duration(global.WaitTimeout) * time.Second)
+	}
 	setActiveRuntimeFromBaseGlobals()
 	mode := os.Getenv("UCLOUD_CLI_DEBUG")
 	if mode == "on" || global.Debug {
@@ -317,6 +322,14 @@ func init() {
 				fmt.Printf("parse timeout-sec failed: %v\n", err)
 			} else {
 				global.Timeout = sec
+			}
+		}
+		if arg == "--wait-timeout-sec" && len(os.Args) > idx+1 && os.Args[idx+1] != "" {
+			sec, err := strconv.Atoi(os.Args[idx+1])
+			if err != nil {
+				fmt.Printf("parse wait-timeout-sec failed: %v\n", err)
+			} else {
+				global.WaitTimeout = sec
 			}
 		}
 		if arg == "--max-retry-times" && len(os.Args) > idx+1 && os.Args[idx+1] != "" {

--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -1,0 +1,83 @@
+package cmd
+
+import "testing"
+
+// TestParseWaitTimeoutSec covers the --wait-timeout-sec startup pre-scan
+// helper, which must accept both the space form (--wait-timeout-sec 1800)
+// and the equals form (--wait-timeout-sec=1800). See issue #119: the equals
+// form was previously silently ignored because init()'s manual os.Args scan
+// only matched arg == "--wait-timeout-sec" exactly.
+func TestParseWaitTimeoutSec(t *testing.T) {
+	tests := []struct {
+		name      string
+		args      []string
+		wantSec   int
+		wantFound bool
+		wantErr   bool
+	}{
+		{
+			name:      "space form",
+			args:      []string{"ucloud", "uhost", "--wait-timeout-sec", "1800"},
+			wantSec:   1800,
+			wantFound: true,
+			wantErr:   false,
+		},
+		{
+			name:      "equals form",
+			args:      []string{"ucloud", "uhost", "--wait-timeout-sec=1800"},
+			wantSec:   1800,
+			wantFound: true,
+			wantErr:   false,
+		},
+		{
+			name:      "absent",
+			args:      []string{"ucloud", "uhost"},
+			wantSec:   0,
+			wantFound: false,
+			wantErr:   false,
+		},
+		{
+			name:      "equals with bad int",
+			args:      []string{"ucloud", "--wait-timeout-sec=abc"},
+			wantSec:   0,
+			wantFound: true,
+			wantErr:   true,
+		},
+		{
+			name:      "space with bad int",
+			args:      []string{"ucloud", "--wait-timeout-sec", "abc"},
+			wantSec:   0,
+			wantFound: true,
+			wantErr:   true,
+		},
+		{
+			name:      "trailing flag no value",
+			args:      []string{"ucloud", "--wait-timeout-sec"},
+			wantSec:   0,
+			wantFound: false,
+			wantErr:   false,
+		},
+		{
+			name:      "empty equals",
+			args:      []string{"ucloud", "--wait-timeout-sec="},
+			wantSec:   0,
+			wantFound: false,
+			wantErr:   false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			sec, found, err := parseWaitTimeoutSec(tt.args)
+			if sec != tt.wantSec {
+				t.Errorf("sec = %d, want %d", sec, tt.wantSec)
+			}
+			if found != tt.wantFound {
+				t.Errorf("found = %v, want %v", found, tt.wantFound)
+			}
+			if (err != nil) != tt.wantErr {
+				t.Errorf("err = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}

--- a/pkg/cli/context.go
+++ b/pkg/cli/context.go
@@ -55,7 +55,7 @@ type Context struct {
 	logWarn     func(io.Writer, ...string)
 	logError    func(io.Writer, ...string)
 	logFilePath func() string
-	newPoller   func(func(string, *request.CommonBase) (interface{}, error), io.Writer) Poller
+	newPoller   func(func(string, *request.CommonBase) (interface{}, error), io.Writer, ...PollerOption) Poller
 
 	// errCount tallies HandleError calls this invocation so the host (cmd) can
 	// set a non-zero exit code when any product error occurred (aws/gcloud
@@ -88,7 +88,7 @@ type Deps struct {
 	LogWarn     func(io.Writer, ...string)
 	LogError    func(io.Writer, ...string)
 	LogFilePath func() string
-	NewPoller   func(func(string, *request.CommonBase) (interface{}, error), io.Writer) Poller
+	NewPoller   func(func(string, *request.CommonBase) (interface{}, error), io.Writer, ...PollerOption) Poller
 }
 
 // NewContext constructs a Context from the provided Deps.

--- a/pkg/cli/forward.go
+++ b/pkg/cli/forward.go
@@ -177,14 +177,14 @@ func (c *Context) LogFilePath() string { return c.logFilePath() }
 func (c *Context) PickResourceID(s string) string { return PickResourceID(s) }
 
 // Poller returns a platform poller bound to ctx's writer.
-func (c *Context) Poller(describeFunc func(string, *request.CommonBase) (interface{}, error)) Poller {
-	return c.newPoller(describeFunc, c.out)
+func (c *Context) Poller(describeFunc func(string, *request.CommonBase) (interface{}, error), opts ...PollerOption) Poller {
+	return c.newPoller(describeFunc, c.out, opts...)
 }
 
 // PollerTo wraps base.NewSpoller bound to an explicit writer, so callers can
 // route progress narration to stderr (e.g. in json/yaml mode) while keeping
 // machine output on stdout. Products cannot import base directly, so this
 // exposes the writer-parameterized poller through the Context.
-func (c *Context) PollerTo(w io.Writer, describeFunc func(string, *request.CommonBase) (interface{}, error)) Poller {
-	return c.newPoller(describeFunc, w)
+func (c *Context) PollerTo(w io.Writer, describeFunc func(string, *request.CommonBase) (interface{}, error), opts ...PollerOption) Poller {
+	return c.newPoller(describeFunc, w, opts...)
 }

--- a/pkg/cli/forward_test.go
+++ b/pkg/cli/forward_test.go
@@ -77,8 +77,8 @@ func TestContextBindCommonParams(t *testing.T) {
 
 func TestContextPollerToReturnsProductCompatiblePoller(t *testing.T) {
 	ctx := cli.NewContext(cli.Deps{
-		NewPoller: func(describe func(string, *request.CommonBase) (interface{}, error), out io.Writer) cli.Poller {
-			return cli.NewPoller(describe, out)
+		NewPoller: func(describe func(string, *request.CommonBase) (interface{}, error), out io.Writer, opts ...cli.PollerOption) cli.Poller {
+			return cli.NewPoller(describe, out, opts...)
 		},
 	})
 

--- a/pkg/cli/poller.go
+++ b/pkg/cli/poller.go
@@ -31,12 +31,25 @@ type poller struct {
 	timeout     time.Duration
 }
 
+// defaultPollTimeout 是一次同步轮询的总等待预算。默认 10 分钟；可经
+// SetDefaultPollTimeout 覆盖（cmd 层接到 --wait-timeout-sec）。
+var defaultPollTimeout = 10 * time.Minute
+
+// SetDefaultPollTimeout 覆盖此后由 NewPoller 创建的 poller 的总超时。
+// 非正值被忽略：SDK 的 waiter 在 Timeout==0 时直接报错（errTimeoutConf），
+// 故此时保留内置默认，不将其置 0。
+func SetDefaultPollTimeout(d time.Duration) {
+	if d > 0 {
+		defaultPollTimeout = d
+	}
+}
+
 func NewPoller(describe func(string, *request.CommonBase) (interface{}, error), out io.Writer) Poller {
 	return &poller{
 		describe:    describe,
 		out:         out,
 		stateFields: []string{"State", "Status"},
-		timeout:     10 * time.Minute,
+		timeout:     defaultPollTimeout,
 	}
 }
 

--- a/pkg/cli/poller.go
+++ b/pkg/cli/poller.go
@@ -25,10 +25,11 @@ type Poller interface {
 }
 
 type poller struct {
-	describe    func(string, *request.CommonBase) (interface{}, error)
-	out         io.Writer
-	stateFields []string
-	timeout     time.Duration
+	describe       func(string, *request.CommonBase) (interface{}, error)
+	out            io.Writer
+	stateFields    []string
+	commandTimeout time.Duration
+	timeout        time.Duration
 }
 
 // builtinPollTimeout 是同步轮询的内置兜底总超时。
@@ -58,13 +59,30 @@ func effectivePollTimeout(commandTimeout time.Duration) time.Duration {
 	return builtinPollTimeout
 }
 
-func NewPoller(describe func(string, *request.CommonBase) (interface{}, error), out io.Writer) Poller {
-	return &poller{
+// PollerOption 定制单个 poller 的创建。
+type PollerOption func(*poller)
+
+// WithTimeout 让单个命令声明自己的默认轮询超时。非正值被忽略。
+// 优先级低于用户 --wait-timeout-sec、高于内置默认（见 effectivePollTimeout）。
+func WithTimeout(d time.Duration) PollerOption {
+	return func(p *poller) {
+		if d > 0 {
+			p.commandTimeout = d
+		}
+	}
+}
+
+func NewPoller(describe func(string, *request.CommonBase) (interface{}, error), out io.Writer, opts ...PollerOption) Poller {
+	p := &poller{
 		describe:    describe,
 		out:         out,
 		stateFields: []string{"State", "Status"},
-		timeout:     effectivePollTimeout(0),
 	}
+	for _, o := range opts {
+		o(p)
+	}
+	p.timeout = effectivePollTimeout(p.commandTimeout)
+	return p
 }
 
 func (p *poller) Spoll(resourceID, pollText string, targetStates []string) {

--- a/pkg/cli/poller.go
+++ b/pkg/cli/poller.go
@@ -31,17 +31,31 @@ type poller struct {
 	timeout     time.Duration
 }
 
-// defaultPollTimeout 是一次同步轮询的总等待预算。默认 10 分钟；可经
-// SetDefaultPollTimeout 覆盖（cmd 层接到 --wait-timeout-sec）。
-var defaultPollTimeout = 10 * time.Minute
+// builtinPollTimeout 是同步轮询的内置兜底总超时。
+const builtinPollTimeout = 10 * time.Minute
 
-// SetDefaultPollTimeout 覆盖此后由 NewPoller 创建的 poller 的总超时。
+// userPollTimeout 是用户经 --wait-timeout-sec 指定的轮询超时（cmd 层启动时注入）。
+// 0 表示用户未指定。它是全局最高优先级，覆盖任何命令自设的默认。
+var userPollTimeout time.Duration
+
+// SetUserPollTimeout 设置用户层轮询超时（cmd 层接 --wait-timeout-sec）。
 // 非正值被忽略：SDK 的 waiter 在 Timeout==0 时直接报错（errTimeoutConf），
-// 故此时保留内置默认，不将其置 0。
-func SetDefaultPollTimeout(d time.Duration) {
+// 故此时保留其余层级，不将其置 0。
+func SetUserPollTimeout(d time.Duration) {
 	if d > 0 {
-		defaultPollTimeout = d
+		userPollTimeout = d
 	}
+}
+
+// effectivePollTimeout 按 用户 > 命令自设 > 内置 的优先级裁决最终超时。
+func effectivePollTimeout(commandTimeout time.Duration) time.Duration {
+	if userPollTimeout > 0 {
+		return userPollTimeout
+	}
+	if commandTimeout > 0 {
+		return commandTimeout
+	}
+	return builtinPollTimeout
 }
 
 func NewPoller(describe func(string, *request.CommonBase) (interface{}, error), out io.Writer) Poller {
@@ -49,7 +63,7 @@ func NewPoller(describe func(string, *request.CommonBase) (interface{}, error), 
 		describe:    describe,
 		out:         out,
 		stateFields: []string{"State", "Status"},
-		timeout:     defaultPollTimeout,
+		timeout:     effectivePollTimeout(0),
 	}
 }
 

--- a/pkg/cli/poller_test.go
+++ b/pkg/cli/poller_test.go
@@ -86,22 +86,42 @@ func TestNewPollerDefaultTimeout(t *testing.T) {
 	}
 }
 
-func TestSetDefaultPollTimeoutOverride(t *testing.T) {
-	defer SetDefaultPollTimeout(10 * time.Minute) // 恢复默认，避免污染其他用例
-	SetDefaultPollTimeout(30 * time.Minute)
+func TestSetUserPollTimeoutOverride(t *testing.T) {
+	defer func() { userPollTimeout = 0 }() // 直接复位；SetUserPollTimeout(0) 会被守卫忽略
+	SetUserPollTimeout(30 * time.Minute)
 	p := NewPoller(pollNoop, &bytes.Buffer{}).(*poller)
 	if p.timeout != 30*time.Minute {
-		t.Errorf("after SetDefaultPollTimeout(30m), timeout = %v, want 30m", p.timeout)
+		t.Errorf("after SetUserPollTimeout(30m), timeout = %v, want 30m", p.timeout)
 	}
 }
 
-func TestSetDefaultPollTimeoutIgnoresNonPositive(t *testing.T) {
-	defer SetDefaultPollTimeout(10 * time.Minute)
-	SetDefaultPollTimeout(30 * time.Minute)
-	SetDefaultPollTimeout(0)                // 0 应被忽略（SDK 会拒绝 Timeout==0）
-	SetDefaultPollTimeout(-5 * time.Minute) // 负值应被忽略
+func TestSetUserPollTimeoutIgnoresNonPositive(t *testing.T) {
+	defer func() { userPollTimeout = 0 }()
+	SetUserPollTimeout(30 * time.Minute)
+	SetUserPollTimeout(0)                // 忽略
+	SetUserPollTimeout(-5 * time.Minute) // 忽略
 	p := NewPoller(pollNoop, &bytes.Buffer{}).(*poller)
 	if p.timeout != 30*time.Minute {
-		t.Errorf("non-positive SetDefaultPollTimeout must be ignored, timeout = %v, want 30m", p.timeout)
+		t.Errorf("non-positive SetUserPollTimeout must be ignored, timeout = %v, want 30m", p.timeout)
+	}
+}
+
+func TestEffectivePollTimeoutPriority(t *testing.T) {
+	defer func() { userPollTimeout = 0 }()
+
+	// 都未设 → builtin
+	userPollTimeout = 0
+	if got := effectivePollTimeout(0); got != 10*time.Minute {
+		t.Errorf("no user, no command: got %v, want 10m", got)
+	}
+	// 仅命令自设 → command
+	userPollTimeout = 0
+	if got := effectivePollTimeout(20 * time.Minute); got != 20*time.Minute {
+		t.Errorf("command only: got %v, want 20m", got)
+	}
+	// 用户已设 → user 覆盖命令
+	userPollTimeout = 15 * time.Minute
+	if got := effectivePollTimeout(20 * time.Minute); got != 15*time.Minute {
+		t.Errorf("user overrides command: got %v, want 15m", got)
 	}
 }

--- a/pkg/cli/poller_test.go
+++ b/pkg/cli/poller_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/ucloud/ucloud-sdk-go/ucloud/request"
 
@@ -69,5 +70,38 @@ func TestPollerSspollNonTTYDone(t *testing.T) {
 		if strings.ContainsRune(out, r) {
 			t.Errorf("spinner frame %q leaked into non-TTY Sspoll output: %q", r, out)
 		}
+	}
+}
+
+// pollNoop 是仅用于构造 poller 的空 describe 函数。
+func pollNoop(string, *request.CommonBase) (interface{}, error) { return nil, nil }
+
+func TestNewPollerDefaultTimeout(t *testing.T) {
+	p, ok := NewPoller(pollNoop, &bytes.Buffer{}).(*poller)
+	if !ok {
+		t.Fatalf("NewPoller did not return *poller")
+	}
+	if p.timeout != 10*time.Minute {
+		t.Errorf("default poll timeout = %v, want 10m", p.timeout)
+	}
+}
+
+func TestSetDefaultPollTimeoutOverride(t *testing.T) {
+	defer SetDefaultPollTimeout(10 * time.Minute) // 恢复默认，避免污染其他用例
+	SetDefaultPollTimeout(30 * time.Minute)
+	p := NewPoller(pollNoop, &bytes.Buffer{}).(*poller)
+	if p.timeout != 30*time.Minute {
+		t.Errorf("after SetDefaultPollTimeout(30m), timeout = %v, want 30m", p.timeout)
+	}
+}
+
+func TestSetDefaultPollTimeoutIgnoresNonPositive(t *testing.T) {
+	defer SetDefaultPollTimeout(10 * time.Minute)
+	SetDefaultPollTimeout(30 * time.Minute)
+	SetDefaultPollTimeout(0)                // 0 应被忽略（SDK 会拒绝 Timeout==0）
+	SetDefaultPollTimeout(-5 * time.Minute) // 负值应被忽略
+	p := NewPoller(pollNoop, &bytes.Buffer{}).(*poller)
+	if p.timeout != 30*time.Minute {
+		t.Errorf("non-positive SetDefaultPollTimeout must be ignored, timeout = %v, want 30m", p.timeout)
 	}
 }

--- a/pkg/cli/poller_test.go
+++ b/pkg/cli/poller_test.go
@@ -125,3 +125,33 @@ func TestEffectivePollTimeoutPriority(t *testing.T) {
 		t.Errorf("user overrides command: got %v, want 15m", got)
 	}
 }
+
+func TestWithTimeoutSetsCommandTimeout(t *testing.T) {
+	defer func() { userPollTimeout = 0 }()
+	userPollTimeout = 0
+	p := NewPoller(pollNoop, &bytes.Buffer{}, WithTimeout(30*time.Minute)).(*poller)
+	if p.commandTimeout != 30*time.Minute {
+		t.Errorf("commandTimeout = %v, want 30m", p.commandTimeout)
+	}
+	if p.timeout != 30*time.Minute {
+		t.Errorf("effective timeout with command option = %v, want 30m", p.timeout)
+	}
+}
+
+func TestWithTimeoutIgnoresNonPositive(t *testing.T) {
+	defer func() { userPollTimeout = 0 }()
+	userPollTimeout = 0
+	p := NewPoller(pollNoop, &bytes.Buffer{}, WithTimeout(0), WithTimeout(-5*time.Minute)).(*poller)
+	if p.timeout != 10*time.Minute {
+		t.Errorf("non-positive WithTimeout must be ignored, timeout = %v, want builtin 10m", p.timeout)
+	}
+}
+
+func TestUserFlagOverridesCommandOption(t *testing.T) {
+	defer func() { userPollTimeout = 0 }()
+	SetUserPollTimeout(20 * time.Minute)
+	p := NewPoller(pollNoop, &bytes.Buffer{}, WithTimeout(30*time.Minute)).(*poller)
+	if p.timeout != 20*time.Minute {
+		t.Errorf("user flag must override command option: timeout = %v, want 20m", p.timeout)
+	}
+}

--- a/pkg/cli/progress.go
+++ b/pkg/cli/progress.go
@@ -50,8 +50,8 @@ func (p *Progress) Refresh(text string) { ui.NewRefresh(p.out).Do(text) }
 
 // Sspoll runs the concurrent poller into block, bound to the progress writer.
 func (p *Progress) Sspoll(describe func(string, *request.CommonBase) (interface{}, error),
-	resourceID, text string, targetStates []string, block *Block, common *request.CommonBase) {
-	NewPoller(describe, p.out).Sspoll(resourceID, text, targetStates, block, common)
+	resourceID, text string, targetStates []string, block *Block, common *request.CommonBase, opts ...PollerOption) {
+	NewPoller(describe, p.out, opts...).Sspoll(resourceID, text, targetStates, block, common)
 }
 
 // ConcurrentAction runs actionFunc over reqs with bounded concurrency (limit),


### PR DESCRIPTION
## 背景

Fixes #119。同步任务轮询（等待资源到达目标状态，如创建集群/主机）的总超时此前被硬编码为 10 分钟（`pkg/cli/poller.go`），无法调整，导致耗时 >10min 的同步创建必然超时。

## 改动

- **pkg/cli**：新增包级默认轮询超时 + `SetDefaultPollTimeout(d)`（忽略非正值，规避 SDK waiter `Timeout==0` 直接报错的陷阱）；`NewPoller` 读取该默认值。三条 poller 创建路径（`ctx.Poller/PollerTo`、`progress.Sspoll`、`cmd/api.go` repeats poller）均收敛到包级 `NewPoller`，单点注入即全覆盖。
- **cmd**：新增全局 flag `--wait-timeout-sec`（单位秒，`0`=用内置默认 600s），与既有 `--timeout-sec`（单次 HTTP 请求超时）**相互独立**；启动时注入到 poller。
- 同时支持 `--wait-timeout-sec 1800` 与 `--wait-timeout-sec=1800` 两种写法。

## 兼容性

默认保持 10 分钟不变，未传 flag 时行为完全不变。

## 测试

- `pkg/cli`：默认值 / 覆盖 / 非正值忽略 单测
- `cmd`：`--wait-timeout-sec` 解析 helper 单测（空格 / 等号 / 边界 / 非法值，7 用例）
- `go build` / `go vet` / `go test`（cmd + pkg/cli）全绿

## 说明

`--wait-timeout-sec` 经 `applyGlobalOverrideFlags` 注册，遵循与现有全局 override flag 一致的排除规则（`init/gendoc/config/auth`）。
