### PR TITLE
fix(cli): recognize --flag=value form in startup arg pre-scan

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -308,37 +308,39 @@ func init() {
 
 	//-1表示不覆盖配置文件中的MaxRetryTimes参数
 	global.MaxRetryTimes = -1
-	for idx, arg := range os.Args {
-		if arg == "--profile" && len(os.Args) > idx+1 && os.Args[idx+1] != "" {
-			global.Profile = os.Args[idx+1]
+	// 启动期预扫描：在 cobra 解析前把连接类参数落到 global.*，供 InitClientRuntime 用。
+	// 每个 flag 都识别 `--flag value` 与 `--flag=value` 两形式（scanFlagValue）。
+	// --profile 额外识别短选项 -p：漏识别会让 ConfigIns 指向错误 profile，
+	// OAuth 刷新可能把别人的 Bearer 重放到当前请求（见 platform/client.go 注释）。
+	if v, ok := scanFlagValue(os.Args, "--profile", "-p"); ok {
+		global.Profile = v
+	}
+	if v, ok := scanFlagValue(os.Args, "--public-key"); ok {
+		global.PublicKey = v
+	}
+	if v, ok := scanFlagValue(os.Args, "--private-key"); ok {
+		global.PrivateKey = v
+	}
+	if v, ok := scanFlagValue(os.Args, "--base-url"); ok {
+		global.BaseURL = v
+	}
+	if v, ok := scanFlagValue(os.Args, "--channel-key"); ok {
+		global.ChannelKey = v
+	}
+	if v, ok := scanFlagValue(os.Args, "--timeout-sec"); ok {
+		sec, err := strconv.Atoi(v)
+		if err != nil {
+			fmt.Printf("parse timeout-sec failed: %v\n", err)
+		} else {
+			global.Timeout = sec
 		}
-		if arg == "--public-key" && len(os.Args) > idx+1 && os.Args[idx+1] != "" {
-			global.PublicKey = os.Args[idx+1]
-		}
-		if arg == "--private-key" && len(os.Args) > idx+1 && os.Args[idx+1] != "" {
-			global.PrivateKey = os.Args[idx+1]
-		}
-		if arg == "--base-url" && len(os.Args) > idx+1 && os.Args[idx+1] != "" {
-			global.BaseURL = os.Args[idx+1]
-		}
-		if arg == "--channel-key" && len(os.Args) > idx+1 && os.Args[idx+1] != "" {
-			global.ChannelKey = os.Args[idx+1]
-		}
-		if arg == "--timeout-sec" && len(os.Args) > idx+1 && os.Args[idx+1] != "" {
-			sec, err := strconv.Atoi(os.Args[idx+1])
-			if err != nil {
-				fmt.Printf("parse timeout-sec failed: %v\n", err)
-			} else {
-				global.Timeout = sec
-			}
-		}
-		if arg == "--max-retry-times" && len(os.Args) > idx+1 && os.Args[idx+1] != "" {
-			times, err := strconv.Atoi(os.Args[idx+1])
-			if err != nil {
-				fmt.Printf("parse max-retry-times failed: %v\n", err)
-			} else {
-				global.MaxRetryTimes = times
-			}
+	}
+	if v, ok := scanFlagValue(os.Args, "--max-retry-times"); ok {
+		times, err := strconv.Atoi(v)
+		if err != nil {
+			fmt.Printf("parse max-retry-times failed: %v\n", err)
+		} else {
+			global.MaxRetryTimes = times
 		}
 	}
 	if sec, found, err := parseWaitTimeoutSec(os.Args); found {
@@ -349,6 +351,34 @@ func init() {
 		}
 	}
 	cobra.EnableCommandSorting = false
+}
+
+// scanFlagValue finds the value of any of names in args, recognizing both the
+// space form (`--profile foo`) and the equals form (`--profile=foo`). Multiple
+// names allow aliases, e.g. scanFlagValue(args, "--profile", "-p"). The first
+// (leftmost) hit wins; an empty value (`--profile=` or a trailing `--profile`
+// with no following arg) counts as no hit and scanning continues.
+//
+// This is the startup pre-scan that must run before cobra parses flags, because
+// connection-class params (base-url/channel-key/profile/keys) must be settled
+// before InitClientRuntime builds sdk.Config. Exact-comparison-only scans missed
+// the equals form — the same #119 bug parseWaitTimeoutSec already fixed for
+// --wait-timeout-sec. Attached/combined shorthand (`-pfoo`, `-dpfoo`) is out of
+// scope: hand-parsing combined shorthand is error-prone and its residual risk
+// matches today's behavior (the pre-scan never recognized `-p` at all).
+func scanFlagValue(args []string, names ...string) (string, bool) {
+	for i, arg := range args {
+		for _, name := range names {
+			if arg == name {
+				if i+1 < len(args) && args[i+1] != "" {
+					return args[i+1], true
+				}
+			} else if v, ok := strings.CutPrefix(arg, name+"="); ok && v != "" {
+				return v, true
+			}
+		}
+	}
+	return "", false
 }
 
 // parseWaitTimeoutSec scans args for --wait-timeout-sec in either

--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -81,3 +81,102 @@ func TestParseWaitTimeoutSec(t *testing.T) {
 		})
 	}
 }
+
+// TestScanFlagValue covers the generalized startup pre-scan helper. Same #119
+// bug as parseWaitTimeoutSec (equals form silently ignored), now for the
+// connection-class flags. The critical -pfoo case pins the R3 boundary:
+// attached/combined shorthand is intentionally NOT recognized.
+func TestScanFlagValue(t *testing.T) {
+	tests := []struct {
+		name      string
+		args      []string
+		names     []string
+		wantVal   string
+		wantFound bool
+	}{
+		{
+			name:      "long space form",
+			args:      []string{"ucloud", "config", "--profile", "foo"},
+			names:     []string{"--profile", "-p"},
+			wantVal:   "foo",
+			wantFound: true,
+		},
+		{
+			name:      "long equals form",
+			args:      []string{"ucloud", "config", "--profile=foo"},
+			names:     []string{"--profile", "-p"},
+			wantVal:   "foo",
+			wantFound: true,
+		},
+		{
+			name:      "short space form",
+			args:      []string{"ucloud", "config", "-p", "foo"},
+			names:     []string{"--profile", "-p"},
+			wantVal:   "foo",
+			wantFound: true,
+		},
+		{
+			name:      "short equals form",
+			args:      []string{"ucloud", "config", "-p=foo"},
+			names:     []string{"--profile", "-p"},
+			wantVal:   "foo",
+			wantFound: true,
+		},
+		{
+			// R3 boundary: attached shorthand is out of scope, must NOT match.
+			name:      "attached shorthand not recognized",
+			args:      []string{"ucloud", "config", "-pfoo"},
+			names:     []string{"--profile", "-p"},
+			wantVal:   "",
+			wantFound: false,
+		},
+		{
+			name:      "empty equals is no hit",
+			args:      []string{"ucloud", "config", "--profile="},
+			names:     []string{"--profile", "-p"},
+			wantVal:   "",
+			wantFound: false,
+		},
+		{
+			name:      "trailing flag no value",
+			args:      []string{"ucloud", "config", "--profile"},
+			names:     []string{"--profile", "-p"},
+			wantVal:   "",
+			wantFound: false,
+		},
+		{
+			name:      "absent",
+			args:      []string{"ucloud", "config"},
+			names:     []string{"--profile", "-p"},
+			wantVal:   "",
+			wantFound: false,
+		},
+		{
+			name:      "base-url equals form single name",
+			args:      []string{"ucloud", "uhost", "list", "--base-url=http://x/"},
+			names:     []string{"--base-url"},
+			wantVal:   "http://x/",
+			wantFound: true,
+		},
+		{
+			// leftmost hit wins (pre-scan only needs one early value, no override)
+			name:      "leftmost wins",
+			args:      []string{"ucloud", "--profile", "a", "--profile", "b"},
+			names:     []string{"--profile", "-p"},
+			wantVal:   "a",
+			wantFound: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			val, found := scanFlagValue(tt.args, tt.names...)
+			if val != tt.wantVal {
+				t.Errorf("val = %q, want %q", val, tt.wantVal)
+			}
+			if found != tt.wantFound {
+				t.Errorf("found = %v, want %v", found, tt.wantFound)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## 问题

`cmd/root.go` 的 `init()` 在 cobra 解析**之前**手写扫描 os.Args，把连接类参数落到 `global.*`（时序约束：这些参数须在 `InitClientRuntime` 构造 `sdk.Config` 前定型）。但扫描用精确比较 `arg == "--base-url"`，只匹配空格形式：

- `--base-url X`（两个 argv）→ 匹配 ✅
- `--base-url=X`（一个 argv）→ **不匹配，被静默无视** ❌

受影响：`--base-url`、`--profile`（含短选项 `-p`）、`--public-key`、`--private-key`、`--channel-key`、`--timeout-sec`、`--max-retry-times`。

### 这不是新 bug — issue #119 已为一个 flag 修过

`parseWaitTimeoutSec`（`root.go`）用 `strings.CutPrefix(arg, flag+"=")` 已是双形式模板，并有表驱动测试 `TestParseWaitTimeoutSec`。其余 flag 当年没跟着改。本 PR 把该修复推广开。

### `--profile=X` / `-p X` 是安全问题

`platform/client.go` 注释已载明：扫描漏识别 `-p X`/`--profile=X` → ConfigIns 指向另一个 profile → OAuth token 刷新可能把**别人的 Bearer 重放到当前请求**。讽刺的是 `config` 命令的官方 Example 就写着 `--profile=test`。

## 实测：今天这些形式操作的是错误的 profile

两个 profile（default 活动 / prod 非活动，base_url 各不同），命令意图操作 prod：

| 形式 | master(现状) | 本 PR | 变化 |
| - | - | - | - |
| （无 `--profile`） | default | default | 零变化（最常见） |
| `--profile prod`（空格） | prod | prod | 零变化（最常用显式写法） |
| `--profile=prod`（等号） | **default ← 错** | prod | 修复 |
| `-p prod`（短选项空格） | **default ← 错** | prod | 修复 |
| `-p=prod`（短等号） | **default ← 错** | prod | 修复 |

**注意 `-p prod`**：文档明载的短选项，今天操作的却是 default 而非 prod。用户跑 `ucloud uhost list -p prod` 拿到的是 default 的列表。这不是「打断正常使用」，是纠正一个一直在悄悄用错 profile 的写法。

## 方案

抽通用 helper `scanFlagValue(args, names...)`（模仿 `parseWaitTimeoutSec`，支持 `--profile`/`-p` 多别名），识别 `name value` 与 `name=value` 两形式，空值视为未命中。`init()` 的 7 处精确比较扫描全部改为调它。

**附着/组合短选项（`-pfoo`、`-dpfoo`）有意不处理**：手工解析组合短选项易错，且其残留风险与现状持平（现状 `-p` 任何形式都不早识别）。`TestScanFlagValue` 用 `-pfoo → ("", false)` 守住该边界。

`parseWaitTimeoutSec` 及其 #119 测试保留不动。

## 测试

- `TestScanFlagValue`（10 用例）：长/短 × 空格/等号、空值、末尾无值、附着不识别、多别名、靠前优先。
- 既有 `TestParseWaitTimeoutSec` 仍绿。
- 全量回归 `go test ./...` 全绿，`go vet` 干净。
- **端到端**：上表即真实二进制实测（master vs 本 PR）。`--base-url=X` 亦实测：master 无视、照打旧地址，本 PR 生效。
- **变异测试**：去掉 `=` 识别，等号用例立刻红 → 证明测试守护该修复。

> ⚠️ CI 的 test job 不含 `./cmd/...`（`pr-gate.yml`），本 PR 用例 CI 不跑，请本地 `go test ./cmd/... -count=1`。

## 行为变更（需入发版说明）

`--flag=value` 等号形式此前静默失效、现生效。尤其：

> 若你用过 `--profile=X`、`-p X` 或 `-p=X`，此前因 bug 它们实际操作**默认 profile**；现已修正为操作 X。请核对脚本是否指向预期 profile。

空格形式（`--flag value`）与不带 flag 的行为**零变化**。属安全修复（消除 profile/Bearer 错配窗口）+ 能力恢复（等号形式生效）。

## 不在本 PR 范围

- **不改 `-h` / `resetHelpFunc`**（与本问题同源，但已裁定不改）。
- 不处理附着/组合短选项（`-pfoo`/`-dpfoo`）。
- 只改 `root.go` + `root_test.go`，不碰 configure.go，与 #142/#143 无冲突，可独立合入。
