### PR TITLE
fix(cmd): preserve user-supplied base-url in ucloud init

### DIFF
--- a/cmd/configure.go
+++ b/cmd/configure.go
@@ -99,7 +99,6 @@ func NewCmdInit() *cobra.Command {
 				fmt.Println("No default project, skip.")
 			}
 			platform.ConfigIns.Timeout = platform.DefaultTimeoutSec
-			platform.ConfigIns.BaseURL = platform.DefaultBaseURL
 			platform.ConfigIns.MaxRetryTimes = sdk.Int(platform.DefaultMaxRetryTimes)
 			platform.ConfigIns.Active = true
 			fmt.Printf("Configured default base url:%s\n", platform.ConfigIns.BaseURL)

--- a/cmd/configure_test.go
+++ b/cmd/configure_test.go
@@ -6,9 +6,13 @@ import (
 	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
+	"os"
 	"path/filepath"
 	"strings"
 	"testing"
+	"time"
+
+	sdk "github.com/ucloud/ucloud-sdk-go/ucloud"
 
 	"github.com/ucloud/ucloud-cli/cmd/internal/platform"
 )
@@ -201,5 +205,98 @@ func TestInitSaveOverwritesExistingOAuthOnlyProfile(t *testing.T) {
 	if got.AccessToken != "" || got.RefreshToken != "" || got.ExpiresAt != 0 {
 		t.Errorf("oauth tokens must be cleared on disk, got access_token=%q refresh_token=%q expires_at=%d",
 			got.AccessToken, got.RefreshToken, got.ExpiresAt)
+	}
+}
+
+// stubStdin 把 os.Stdin 换成预置内容的临时文件，驱动 init 流程里的 fmt.Scanf 交互
+func stubStdin(t *testing.T, input string) {
+	t.Helper()
+	f, err := os.CreateTemp(t.TempDir(), "stdin")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := f.WriteString(input); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := f.Seek(0, io.SeekStart); err != nil {
+		t.Fatal(err)
+	}
+	old := os.Stdin
+	os.Stdin = f
+	t.Cleanup(func() {
+		os.Stdin = old
+		f.Close()
+	})
+}
+
+// 回归：init 交互中用户输入的自定义 base-url 必须落盘。曾在流程末尾无条件回填
+// DefaultBaseURL，导致输入的专属云域名只在远程校验期生效、存盘的却是主站默认值，
+// 且回显的也是覆盖后的值，用户无从察觉。
+func TestInitPersistsUserSuppliedBaseURL(t *testing.T) {
+	gateway := fakeGatewayServer(t)
+	defer gateway.Close()
+
+	dir := t.TempDir()
+	cfgPath := filepath.Join(dir, "config.json")
+	credPath := filepath.Join(dir, "credential.json")
+
+	m, err := platform.NewAggConfigManager(cfgPath, credPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	// 全新 init 现场：profile 尚未落盘，BaseURL 为包级默认值。timeout/max-retry 取小值让
+	// 远程校验打本地假网关时快速收敛（init 末尾仍会把二者重置为各自默认值）
+	cfg := &platform.AggConfig{
+		Profile:       platform.DefaultProfile,
+		BaseURL:       platform.DefaultBaseURL,
+		Timeout:       3,
+		MaxRetryTimes: sdk.Int(0),
+	}
+
+	oldCfgPath, oldCredPath := platform.ConfigFilePath, platform.CredentialFilePath
+	oldM, oldC := platform.AggConfigListIns, platform.ConfigIns
+	oldCC, oldAC, oldRT := platform.ClientConfig, platform.AuthCredential, activeRuntime
+	// Run 末尾的 InitConfig 按包级路径读写配置，指向临时目录避免污染真实 ~/.ucloud
+	platform.ConfigFilePath, platform.CredentialFilePath = cfgPath, credPath
+	platform.AggConfigListIns, platform.ConfigIns = m, cfg
+	// ConfigPublicKey/ConfigPrivateKey 直接写 AuthCredential，为 nil 会 panic
+	platform.AuthCredential = &platform.CredentialConfig{}
+	// 末尾 printHello 经 activeRuntime 取 client：钉到假网关，避免测试真的打外网
+	platform.ClientConfig = &sdk.Config{BaseUrl: gateway.URL, Timeout: 3 * time.Second}
+	setActiveRuntimeFromBaseGlobals()
+	defer func() {
+		platform.ConfigFilePath, platform.CredentialFilePath = oldCfgPath, oldCredPath
+		platform.AggConfigListIns, platform.ConfigIns = oldM, oldC
+		platform.ClientConfig, platform.AuthCredential, activeRuntime = oldCC, oldAC, oldRT
+	}()
+
+	// init 依次 Scanf 读取：public-key、private-key、base-url、是否上传日志
+	stubStdin(t, fmt.Sprintf("pub\npri\n%s\nno\n", gateway.URL))
+
+	cmd := NewCmdInit()
+	cmd.Run(cmd, nil)
+
+	// 重新读盘验证持久化，而非只看内存
+	m2, err := platform.NewAggConfigManager(cfgPath, credPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	got, ok := m2.GetAggConfigByProfile(platform.DefaultProfile)
+	if !ok {
+		t.Fatal("profile default missing after reload")
+	}
+	if got.BaseURL != gateway.URL {
+		t.Errorf("base_url on disk = %q, want user supplied %q (init must not overwrite it with the default %q)",
+			got.BaseURL, gateway.URL, platform.DefaultBaseURL)
+	}
+	// 同一流程里 init 本就该落的默认值，不能被本次修复带偏
+	if got.Timeout != platform.DefaultTimeoutSec {
+		t.Errorf("timeout_sec on disk = %d, want default %d", got.Timeout, platform.DefaultTimeoutSec)
+	}
+	if got.MaxRetryTimes == nil || *got.MaxRetryTimes != platform.DefaultMaxRetryTimes {
+		t.Errorf("max_retry_times on disk = %v, want default %d", got.MaxRetryTimes, platform.DefaultMaxRetryTimes)
+	}
+	if !got.Active {
+		t.Error("active on disk = false, want true")
 	}
 }


### PR DESCRIPTION
## 缺陷

`ucloud init` 交互中用户输入的自定义 base-url 无法落盘。`NewCmdInit` 在持久化前无条件执行 `platform.ConfigIns.BaseURL = platform.DefaultBaseURL`，把用户输入覆盖回主站默认值：

- 用户输入的域名只在远程校验期（`fetchRegionWithConfig`）生效；
- 落盘的是 `DefaultBaseURL`；
- 末尾的确认行打印的也是被覆盖后的值，用户无从察觉。

专属云客户（需指向 `https://api.ucloud-global.com/` 等非主站网关）走 `ucloud init` 拿不到可用 profile，只能改用 `ucloud config update --base-url ...` 绕过。

## 修复

删除那行无条件覆盖即可。`ConfigBaseURL()` 已保证 `BaseURL` 非空——用户直接回车时 `ConfigIns` 仍保持包级默认值 `DefaultBaseURL`，故删除后默认路径行为不变。

同一段的 `Timeout`/`MaxRetryTimes`/`Active` 保持原样重置：这三项在 init 流程中本就没有用户输入环节，属于合理的初始化，只有 `BaseURL` 在 prompt 处有用户输入，故只改它。

## 测试

新增 `TestInitPersistsUserSuppliedBaseURL`：驱动真实的 `NewCmdInit().Run()`（stdin 喂入公钥/私钥/自定义 base-url/日志选项，配合假网关），重新读盘断言落盘的 base-url 与用户输入一致，同时校验 timeout/max-retry/active 仍为各自默认值（避免过度约束）。已验证把缺陷行放回后该用例变红、且仅 base-url 断言失败。

## 验证

- `/opt/homebrew/bin/go build ./...` 通过
- `go vet ./cmd/...` 无输出
- `go test ./...` 全部包 ok，既有 init/config 用例无回归